### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/models/agdrift/agdrift_model.py
+++ b/models/agdrift/agdrift_model.py
@@ -28,7 +28,7 @@ class agdrift(object):
         self.jid = rest_funcs.gen_jid()
         
         if set_variables:
-            if vars_dict != None:
+            if vars_dict is not None:
                 self.__dict__.update(vars_dict)
             else:
                 self.set_variables(run_type, drop_size, ecosystem_type, application_method, boom_height, orchard_type,

--- a/models/earthworm/earthworm_model.py
+++ b/models/earthworm/earthworm_model.py
@@ -22,7 +22,7 @@ class earthworm(object):
         self.jid = rest_funcs.gen_jid()
         
         if set_variables:
-            if vars_dict != None:
+            if vars_dict is not None:
                 self.__dict__.update(vars_dict)
             else:
                 self.run_methods = run_methods

--- a/models/iec/iec_model.py
+++ b/models/iec/iec_model.py
@@ -19,7 +19,7 @@ class iec(object):
         self.set_default_variables()
         self.jid = rest_funcs.gen_jid()
         if set_variables:
-            if vars_dict != None:
+            if vars_dict is not None:
                 self.__dict__.update(vars_dict)
             else:
                 self.set_variables(run_type,dose_response,lc50,threshold)

--- a/models/insect/insect_model.py
+++ b/models/insect/insect_model.py
@@ -22,7 +22,7 @@ class insect(object):
         self.set_default_variables()
         self.jid = rest_funcs.gen_jid()
         if set_variables:
-            if vars_dict != None:
+            if vars_dict is not None:
                 self.__dict__.update(vars_dict)
             else:
                 self.set_variables(run_type, chemical_name, b_species, m_species, bw_quail, bw_duck, bwb_other, bw_rat, bwm_other, sol, ld50_a, ld50_m, aw_bird, mineau, aw_mamm, noaec_d, noaec_q, noaec_o, Species_of_the_bird_NOAEC_CHOICES, noael)

--- a/models/rice/rice_model.py
+++ b/models/rice/rice_model.py
@@ -26,7 +26,7 @@ class rice(object):
         self.jid = rest_funcs.gen_jid()
 
         if set_variables:
-            if vars_dict != None:
+            if vars_dict is not None:
                 self.__dict__.update(vars_dict)
             else:
                 self.set_variables(version_rice,run_type,chemical_name,mai,dsed,a,pb,dw,osed,kd)

--- a/models/sam/shapefile.py
+++ b/models/sam/shapefile.py
@@ -127,7 +127,7 @@ class _Shape:
                 ps = None
                 coordinates = []
                 for part in self.parts:
-                    if ps == None:
+                    if ps is None:
                         ps = part
                         continue
                     else:
@@ -149,7 +149,7 @@ class _Shape:
                 ps = None
                 coordinates = []
                 for part in self.parts:
-                    if ps == None:
+                    if ps is None:
                         ps = part
                         continue
                     else:
@@ -381,7 +381,7 @@ class Reader:
                 # Offsets are 16-bit words just like the file length
                 self._offsets.append(unpack(">i", shx.read(4))[0] * 2)
                 shx.seek(shx.tell() + 4)
-        if not i == None:
+        if not i is None:
             return self._offsets[i]
 
     def shape(self, i=0):

--- a/models/stir/stir_model.py
+++ b/models/stir/stir_model.py
@@ -30,7 +30,7 @@ class StirModel(object):
                  vars_dict=None):
         self.set_default_variables()
         if set_variables:
-            if vars_dict != None:
+            if vars_dict is not None:
                 self.__dict__.update(vars_dict)
             else:
                 self.set_variables(run_type, chemical_name, application_rate, column_height, spray_drift_fraction,

--- a/views/geoserver.py
+++ b/views/geoserver.py
@@ -69,7 +69,7 @@ def sam_done_query(request, jid):
 
     response = {}
 
-    if request == None:
+    if request is None:
         response['done'] = False
     else:
         try:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:puruckertom:ubertool_eco?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:puruckertom:ubertool_eco?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)